### PR TITLE
fix(view): Another alternative view

### DIFF
--- a/src/ops/style.rs
+++ b/src/ops/style.rs
@@ -1,4 +1,8 @@
 use anstyle::{AnsiColor, Effects, Style};
 
-pub(crate) const YELLOW: Style = AnsiColor::Yellow.on_default().effects(Effects::BOLD);
-pub(crate) const CYAN: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
+pub const NOP: Style = Style::new();
+pub const HEADER: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
+pub const LITERAL: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
+pub const ERROR: Style = AnsiColor::Red.on_default().effects(Effects::BOLD);
+pub const WARN: Style = AnsiColor::Yellow.on_default().effects(Effects::BOLD);
+pub const NOTE: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);

--- a/tests/testsuite/cargo_information/basic/stdout.log
+++ b/tests/testsuite/cargo_information/basic/stdout.log
@@ -1,5 +1,5 @@
-
-my-package@99999.0.0+my-package | No license | deps: 0 | versions: 7 | edition: 2015
-
-lib: my-package
-
+my-package
+version: 99999.0.0+my-package
+license: unknown
+rust-version: unknown
+documentation: https://docs.rs/my-package/99999.0.0+my-package

--- a/tests/testsuite/cargo_information/with_quiet/stdout.log
+++ b/tests/testsuite/cargo_information/with_quiet/stdout.log
@@ -1,5 +1,5 @@
-
-my-package@99999.0.0+my-package | No license | deps: 0 | versions: 7 | edition: 2015
-
-lib: my-package
-
+my-package
+version: 99999.0.0+my-package
+license: unknown
+rust-version: unknown
+documentation: https://docs.rs/my-package/99999.0.0+my-package

--- a/tests/testsuite/cargo_information/within_workspace/stdout.log
+++ b/tests/testsuite/cargo_information/within_workspace/stdout.log
@@ -1,6 +1,6 @@
-
-my-package@0.1.1+my-package | No license | deps: 0 | versions: 7 | edition: 2015
-
-lib: my-package
-
-note: This package is from current workspace. You can use `cargo tree --package my-package@0.1.1+my-package --invert` to view the dependency tree.
+my-package
+version: 0.1.1+my-package (latest 99999.0.0+my-package)
+license: unknown
+rust-version: unknown
+documentation: https://docs.rs/my-package/0.1.1+my-package
+note: to see how you depend on my-package, run `cargo tree --package my-package@0.1.1+my-package --invert`


### PR DESCRIPTION
This primarily is meant to be a simplification so its easier to add / remove content.
We can evaluate fancier formatting, like tables, later when we know more of what we want.

To simplify my work, I cut fields that I wasn't as sure of including.

I also wanted to take a small crack at some formatting changes so the new, plain view was easier to read.

Since I was touching formatting, I went ahead and applied my indentation suggestion.

This is by no means to say "this is THE design" but I think it helps move us in that direction.

![image](https://github.com/hi-rustin/cargo-information/assets/60961/d42360de-68af-4db0-a4e3-dcabbe0d6459)
