### PR TITLE
fix(view): Show features before dependencies

### DIFF
--- a/src/ops/view.rs
+++ b/src/ops/view.rs
@@ -73,9 +73,9 @@ pub(super) fn pretty_view(
         writeln!(stdout, "{header}repository:{reset} {link}")?;
     }
 
-    pretty_deps(package, stdout)?;
-
     pretty_features(summary.features(), stdout)?;
+
+    pretty_deps(package, stdout)?;
 
     Ok(())
 }
@@ -189,7 +189,6 @@ fn pretty_features(features: &FeatureMap, stdout: &mut dyn Write) -> CargoResult
                 .join(", ")
         )?;
     }
-    writeln!(stdout)?;
 
     Ok(())
 }


### PR DESCRIPTION
As features are part of the public API, they are more relevant to the viewer than dependencies, and so they should be a higher priority which correlates with order.