### PR TITLE
fix: Don't style backticks around literals

### DIFF
--- a/src/ops/view.rs
+++ b/src/ops/view.rs
@@ -199,7 +199,7 @@ pub(super) fn suggest_cargo_tree(package_id: PackageId, stdout: &mut dyn Write) 
     let reset = anstyle::Reset.render();
 
     note(format_args!(
-        "to see how you depend on {name}, run {literal}`cargo tree --package {name}@{version} --invert`{reset}",
+        "to see how you depend on {name}, run `{literal}cargo tree --package {name}@{version} --invert{reset}`",
         name = package_id.name(),
         version = package_id.version(),
     ), stdout)


### PR DESCRIPTION
I just noticed that we are inconcistent with the message at the end of `cargo check -h`