### PR TITLE
fix: use replacement sid and remove unnecessary crates.io update

### DIFF
--- a/src/ops/info.rs
+++ b/src/ops/info.rs
@@ -180,7 +180,7 @@ fn get_source_id(
     } else {
         Ok(RegistrySourceIds {
             original: sid,
-            replacement: builtin_replacement_sid,
+            replacement: replacement_sid,
         })
     }
 }

--- a/tests/testsuite/cargo_information/within_workspace/stderr.log
+++ b/tests/testsuite/cargo_information/within_workspace/stderr.log
@@ -1,4 +1,3 @@
     Updating `dummy-registry` index
  Downloading crates ...
   Downloaded my-package v0.1.1+my-package (registry `dummy-registry`)
-    Updating crates.io index


### PR DESCRIPTION
We shouldn't always use built-in replacement source ids here.