### PR TITLE
fix: do now allow empty spec name

### DIFF
--- a/src/bin/cargo-info/command/info.rs
+++ b/src/bin/cargo-info/command/info.rs
@@ -102,6 +102,13 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
         .map(String::as_str)
         .unwrap();
     let spec = PackageIdSpec::parse(package)?;
+    if spec.name().is_empty() {
+        return Err(CliError::new(
+            anyhow::format_err!("package ID specification must have a name"),
+            101,
+        ));
+    }
+
     let reg_or_index = args.registry_or_index(config)?;
     ops::info(&spec, config, reg_or_index)?;
     Ok(())

--- a/tests/testsuite/cargo_information/mod.rs
+++ b/tests/testsuite/cargo_information/mod.rs
@@ -4,6 +4,7 @@ mod basic;
 mod features;
 mod help;
 mod not_found;
+mod specify_empty_version_with_url;
 mod specify_version_outside_ws;
 mod specify_version_with_url_but_registry_is_not_matched;
 mod specify_version_with_ws_and_match_multiple_versions;

--- a/tests/testsuite/cargo_information/specify_empty_version_with_url/mod.rs
+++ b/tests/testsuite/cargo_information/specify_empty_version_with_url/mod.rs
@@ -1,0 +1,23 @@
+use cargo_test_macro::cargo_test;
+use cargo_test_support::{curr_dir, registry::RegistryBuilder};
+
+use super::cargo_info;
+
+#[cargo_test]
+fn case() {
+    let _ = RegistryBuilder::new()
+        .alternative()
+        .no_configure_token()
+        .build();
+    cargo_test_support::registry::Package::new("my-package", "99999.0.0-alpha.1+my-package")
+        .alternative(true)
+        .publish();
+
+    cargo_info()
+        .arg("https://crates.io")
+        .arg("--registry=alternative")
+        .assert()
+        .failure()
+        .stdout_matches_path(curr_dir!().join("stdout.log"))
+        .stderr_matches_path(curr_dir!().join("stderr.log"));
+}

--- a/tests/testsuite/cargo_information/specify_empty_version_with_url/stderr.log
+++ b/tests/testsuite/cargo_information/specify_empty_version_with_url/stderr.log
@@ -1,3 +1,1 @@
-thread 'main' panicked at /Users/hi-rustin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-0.75.1/src/cargo/core/dependency.rs:164:9:
-assertion failed: !name.is_empty()
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+error: package ID specification must have a name

--- a/tests/testsuite/cargo_information/specify_empty_version_with_url/stderr.log
+++ b/tests/testsuite/cargo_information/specify_empty_version_with_url/stderr.log
@@ -1,0 +1,3 @@
+thread 'main' panicked at /Users/hi-rustin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-0.75.1/src/cargo/core/dependency.rs:164:9:
+assertion failed: !name.is_empty()
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
See the test case. We shouldn't allow empty name.