### PR TITLE
docs: add installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ To install `cargo-info`, run the following command:
 cargo install cargo-information --git https://github.com/hi-rustin/cargo-information.git
 ```
 
+### Arch Linux
+
+`cargo-info` can be installed from the [AUR](https://aur.archlinux.org/packages?O=0&SeB=nd&K=cargo-information&outdated=&SB=p&SO=d&PP=50&submit=Go) using an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers). For example:
+
+```bash
+paru -S cargo-information
+```
+
 ## Usage
 
 After installation, you can use the `cargo info` command followed by the package name to get information about a package:


### PR DESCRIPTION
Hello, I packaged `cargo-information` for Arch Linux :bear:

Created following packages:

- https://aur.archlinux.org/packages/cargo-information-git
- https://aur.archlinux.org/packages/cargo-information

This PR simply updates README.md to mention the installation instructions.
