### PR TITLE
feat: add ignore-rust-version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Options:
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
   -q, --quiet                Do not print cargo log messages
       --color <WHEN>         Coloring: auto, always, never
+      --ignore-rust-version  Ignore `rust-version` specification when choosing a version to inspect
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
   -h, --help                 Print help

--- a/src/bin/cargo-info/command/info.rs
+++ b/src/bin/cargo-info/command/info.rs
@@ -54,6 +54,10 @@ fn info_subcommand() -> Command {
                 .help_heading(heading::MANIFEST_OPTIONS)
                 .global(true),
         )
+        .arg(flag(
+            "ignore-rust-version",
+            "Ignore `rust-version` specification when choosing a version to inspect",
+        ))
         .arg(multi_opt("config", "KEY=VALUE", "Override a configuration value").global(true))
         .arg(
             Arg::new("unstable-features")
@@ -75,6 +79,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     let frozen = args.flag("frozen");
     let locked = args.flag("locked");
     let offline = args.flag("offline");
+    let ignore_rust_version = args.flag("ignore-rust-version");
     let unstable_flags: Vec<String> = args
         .get_many::<String>("unstable-features")
         .unwrap_or_default()
@@ -110,7 +115,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     }
 
     let reg_or_index = args.registry_or_index(config)?;
-    ops::info(&spec, config, reg_or_index)?;
+    ops::info(&spec, config, reg_or_index, ignore_rust_version)?;
     Ok(())
 }
 

--- a/tests/testsuite/cargo_information/help/stdout.log
+++ b/tests/testsuite/cargo_information/help/stdout.log
@@ -8,6 +8,7 @@ Options:
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
   -q, --quiet                Do not print cargo log messages
       --color <WHEN>         Coloring: auto, always, never
+      --ignore-rust-version  Ignore `rust-version` specification when choosing a version to inspect
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
   -h, --help                 Print help

--- a/tests/testsuite/cargo_information/ignore_msrv_compatible_check/mod.rs
+++ b/tests/testsuite/cargo_information/ignore_msrv_compatible_check/mod.rs
@@ -1,0 +1,24 @@
+use cargo_test_macro::cargo_test;
+use cargo_test_support::curr_dir;
+
+use super::{cargo_info, init_registry_without_token};
+
+#[cargo_test]
+fn case() {
+    init_registry_without_token();
+    cargo_test_support::registry::Package::new("my-package", "0.1.1+my-package")
+        .rust_version("1.0.0")
+        .publish();
+    cargo_test_support::registry::Package::new("my-package", "0.2.0+my-package")
+        .rust_version("1.9876.0")
+        .publish();
+
+    cargo_info()
+        .arg("my-package")
+        .arg("--registry=dummy-registry")
+        .arg("--ignore-rust-version")
+        .assert()
+        .success()
+        .stdout_matches_path(curr_dir!().join("stdout.log"))
+        .stderr_matches_path(curr_dir!().join("stderr.log"));
+}

--- a/tests/testsuite/cargo_information/ignore_msrv_compatible_check/stderr.log
+++ b/tests/testsuite/cargo_information/ignore_msrv_compatible_check/stderr.log
@@ -1,0 +1,3 @@
+    Updating `dummy-registry` index
+ Downloading crates ...
+  Downloaded my-package v0.2.0+my-package (registry `dummy-registry`)

--- a/tests/testsuite/cargo_information/ignore_msrv_compatible_check/stdout.log
+++ b/tests/testsuite/cargo_information/ignore_msrv_compatible_check/stdout.log
@@ -1,0 +1,4 @@
+my-package
+version: 0.2.0+my-package (from registry `dummy-registry`)
+license: unknown
+rust-version: 1.9876.0

--- a/tests/testsuite/cargo_information/mod.rs
+++ b/tests/testsuite/cargo_information/mod.rs
@@ -3,6 +3,7 @@ use cargo_test_support::{compare, TestEnv};
 mod basic;
 mod features;
 mod help;
+mod ignore_msrv_compatible_check;
 mod not_found;
 mod pick_msrv_compatible_package;
 mod pick_msrv_compatible_package_within_ws;


### PR DESCRIPTION
Add the `--ignore-rust-version` flag.

close https://github.com/hi-rustin/cargo-information/issues/28

