### PR TITLE
fix: Re-order suggested cargo-tree parameters

### DIFF
--- a/src/ops/view.rs
+++ b/src/ops/view.rs
@@ -302,7 +302,7 @@ fn suggest_cargo_tree(package_id: PackageId, stdout: &mut dyn Write) -> CargoRes
     let reset = anstyle::Reset.render();
 
     note(format_args!(
-        "to see how you depend on {name}, run `{literal}cargo tree --package {name}@{version} --invert{reset}`",
+        "to see how you depend on {name}, run `{literal}cargo tree --invert --package {name}@{version}{reset}`",
         name = package_id.name(),
         version = package_id.version(),
     ), stdout)

--- a/tests/testsuite/cargo_information/specify_version_within_ws_and_match_with_lockfile/stdout.log
+++ b/tests/testsuite/cargo_information/specify_version_within_ws_and_match_with_lockfile/stdout.log
@@ -3,4 +3,4 @@ version: 0.1.1+my-package (latest 99999.0.0+my-package)
 license: unknown
 rust-version: unknown
 documentation: https://docs.rs/my-package/0.1.1+my-package
-note: to see how you depend on my-package, run `cargo tree --package my-package@0.1.1+my-package --invert`
+note: to see how you depend on my-package, run `cargo tree --invert --package my-package@0.1.1+my-package`

--- a/tests/testsuite/cargo_information/within_ws/stdout.log
+++ b/tests/testsuite/cargo_information/within_ws/stdout.log
@@ -3,4 +3,4 @@ version: 0.1.1+my-package (latest 99999.0.0+my-package)
 license: unknown
 rust-version: unknown
 documentation: https://docs.rs/my-package/0.1.1+my-package
-note: to see how you depend on my-package, run `cargo tree --package my-package@0.1.1+my-package --invert`
+note: to see how you depend on my-package, run `cargo tree --invert --package my-package@0.1.1+my-package`

--- a/tests/testsuite/cargo_information/within_ws_without_lockfile/stdout.log
+++ b/tests/testsuite/cargo_information/within_ws_without_lockfile/stdout.log
@@ -3,4 +3,4 @@ version: 0.2.3+my-package (latest 0.4.1+my-package)
 license: unknown
 rust-version: unknown
 documentation: https://docs.rs/my-package/0.2.3+my-package
-note: to see how you depend on my-package, run `cargo tree --package my-package@0.2.3+my-package --invert`
+note: to see how you depend on my-package, run `cargo tree --invert --package my-package@0.2.3+my-package`


### PR DESCRIPTION
For myself, I feel like the trailing `--invert` reads a little awkwardly.

Noticed when copying the message for rust-lang/cargo#13372