### PR TITLE
feat: display crates.io link

### DIFF
--- a/src/ops/view.rs
+++ b/src/ops/view.rs
@@ -105,6 +105,15 @@ pub(super) fn pretty_view(
     if let Some(ref link) = metadata.repository {
         writeln!(stdout, "{header}repository:{header:#} {link}")?;
     }
+    // Only print the crates.io link if the package is from crates.io.
+    if summary.source_id().is_crates_io() {
+        writeln!(
+            stdout,
+            "{header}crates.io:{header:#} https://crates.io/crates/{}/{}",
+            package_id.name(),
+            package_id.version()
+        )?;
+    }
 
     pretty_features(summary.features(), stdout)?;
 

--- a/tests/testsuite/cargo_information/git_dependency/mod.rs
+++ b/tests/testsuite/cargo_information/git_dependency/mod.rs
@@ -27,7 +27,7 @@ fn case() {
                 baz.url()
             ),
         )
-        .file("src/lib.rs", &format!(""))
+        .file("src/lib.rs", "")
         .build();
 
     let project_root = foo.root();

--- a/tests/testsuite/cargo_information/specify_version_within_ws_and_match_with_lockfile/stdout.log
+++ b/tests/testsuite/cargo_information/specify_version_within_ws_and_match_with_lockfile/stdout.log
@@ -3,4 +3,5 @@ version: 0.1.1+my-package (latest 99999.0.0+my-package)
 license: unknown
 rust-version: unknown
 documentation: https://docs.rs/my-package/0.1.1+my-package
+crates.io: https://crates.io/crates/my-package/0.1.1+my-package
 note: to see how you depend on my-package, run `cargo tree --invert --package my-package@0.1.1+my-package`

--- a/tests/testsuite/cargo_information/within_ws/stdout.log
+++ b/tests/testsuite/cargo_information/within_ws/stdout.log
@@ -3,4 +3,5 @@ version: 0.1.1+my-package (latest 99999.0.0+my-package)
 license: unknown
 rust-version: unknown
 documentation: https://docs.rs/my-package/0.1.1+my-package
+crates.io: https://crates.io/crates/my-package/0.1.1+my-package
 note: to see how you depend on my-package, run `cargo tree --invert --package my-package@0.1.1+my-package`

--- a/tests/testsuite/cargo_information/within_ws_without_lockfile/stdout.log
+++ b/tests/testsuite/cargo_information/within_ws_without_lockfile/stdout.log
@@ -3,4 +3,5 @@ version: 0.2.3+my-package (latest 0.4.1+my-package)
 license: unknown
 rust-version: unknown
 documentation: https://docs.rs/my-package/0.2.3+my-package
+crates.io: https://crates.io/crates/my-package/0.2.3+my-package
 note: to see how you depend on my-package, run `cargo tree --invert --package my-package@0.2.3+my-package`


### PR DESCRIPTION
close https://github.com/hi-rustin/cargo-information/issues/121

This PR prints the crates.io link if the package is from crates.io.

Tested locally:
<img width="1263" alt="image" src="https://github.com/hi-rustin/cargo-information/assets/29879298/ca5cd163-2acf-4c03-9999-e9c93c0820e9">
