### PR TITLE
feat: Put dependencies behind --verbose

### DIFF
--- a/src/ops/info.rs
+++ b/src/ops/info.rs
@@ -153,15 +153,12 @@ fn query_and_pretty_view(
     let package = registry.get(&[package_id])?;
     let package = package.get_one(package_id)?;
     let owners = try_list_owners(config, source_ids, package_id.name().as_str())?;
-    let mut shell = config.shell();
-    let stdout = shell.out();
     pretty_view(
         package,
         &summaries,
         &owners,
         suggest_cargo_tree_command,
         config,
-        stdout,
     )?;
 
     Ok(())

--- a/src/ops/view.rs
+++ b/src/ops/view.rs
@@ -15,7 +15,6 @@ pub(super) fn pretty_view(
     owners: &Option<Vec<String>>,
     suggest_cargo_tree_command: bool,
     config: &Config,
-    stdout: &mut dyn Write,
 ) -> CargoResult<()> {
     let summary = package.manifest().summary();
     let package_id = summary.package_id();
@@ -25,6 +24,8 @@ pub(super) fn pretty_view(
     let warn = WARN;
     let note = NOTE;
 
+    let mut shell = config.shell();
+    let stdout = shell.out();
     write!(stdout, "{header}{}{header:#}", package_id.name())?;
     if !metadata.keywords.is_empty() {
         write!(stdout, " {note}#{}{note:#}", metadata.keywords.join(" #"))?;

--- a/tests/testsuite/cargo_information/git_dependency/mod.rs
+++ b/tests/testsuite/cargo_information/git_dependency/mod.rs
@@ -1,5 +1,5 @@
 use cargo_test_macro::cargo_test;
-use cargo_test_support::{basic_manifest, file, git, project};
+use cargo_test_support::{basic_manifest, file, git, project, ArgLine as _};
 
 use super::{cargo_info, init_registry_without_token};
 
@@ -34,7 +34,7 @@ fn case() {
     let cwd = &project_root;
 
     cargo_info()
-        .arg("foo")
+        .arg_line("--verbose foo")
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/testsuite/cargo_information/mod.rs
+++ b/tests/testsuite/cargo_information/mod.rs
@@ -14,6 +14,7 @@ mod specify_version_outside_ws;
 mod specify_version_with_url_but_registry_is_not_matched;
 mod specify_version_within_ws_and_conflict_with_lockfile;
 mod specify_version_within_ws_and_match_with_lockfile;
+mod verbose;
 mod with_frozen_outside_ws;
 mod with_frozen_within_ws;
 mod with_locked_outside_ws;

--- a/tests/testsuite/cargo_information/path_dependency/mod.rs
+++ b/tests/testsuite/cargo_information/path_dependency/mod.rs
@@ -1,5 +1,5 @@
 use cargo_test_macro::cargo_test;
-use cargo_test_support::{compare::assert_ui, current_dir, file, Project};
+use cargo_test_support::{compare::assert_ui, current_dir, file, ArgLine as _, Project};
 
 use super::{cargo_info, init_registry_without_token};
 
@@ -12,7 +12,7 @@ fn case() {
     let cwd = &project_root;
 
     cargo_info()
-        .arg("foo")
+        .arg_line("--verbose foo")
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/testsuite/cargo_information/verbose/mod.rs
+++ b/tests/testsuite/cargo_information/verbose/mod.rs
@@ -1,0 +1,52 @@
+use cargo_test_macro::cargo_test;
+use cargo_test_support::file;
+
+use super::{cargo_info_with_color, init_registry_without_token};
+
+#[cargo_test]
+fn case() {
+    init_registry_without_token();
+    cargo_test_support::registry::Package::new("my-package", "0.1.0")
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "my-package"
+            version = "0.1.0"
+            description = "A package for testing"
+            repository = "https://github.com/hi-rustin/cargo-infromation"
+            documentation = "https://docs.rs/my-package/0.1.0"
+            license = "MIT"
+            edition = "2018"
+            rust-version = "1.50.0"
+            keywords = ["foo", "bar", "baz"]
+
+            [features]
+            default = ["feature1"]
+            feature1 = []
+            feature2 = []
+
+            [dependencies]
+            foo = "0.1.0"
+            bar = "0.2.0"
+            baz = { version = "0.3.0", optional = true }
+
+            [[bin]]
+            name = "my_bin"
+
+            [lib]
+            name = "my_lib"
+            "#,
+        )
+        .file("src/bin/my_bin.rs", "")
+        .file("src/lib.rs", "")
+        .publish();
+    cargo_info_with_color()
+        .arg("my-package")
+        .arg("--verbose")
+        .arg("--registry=dummy-registry")
+        .assert()
+        .success()
+        .stdout_matches(file!["stdout.term.svg"])
+        .stderr_matches(file!["stderr.term.svg"]);
+}

--- a/tests/testsuite/cargo_information/verbose/stderr.term.svg
+++ b/tests/testsuite/cargo_information/verbose/stderr.term.svg
@@ -1,0 +1,33 @@
+<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-green { fill: #00AA00 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold"> Downloading</tspan><tspan> crates ...</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">  Downloaded</tspan><tspan> my-package v0.1.0 (registry `dummy-registry`)</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">  Credential</tspan><tspan> cargo:token get dummy-registry</tspan>
+</tspan>
+    <tspan x="10px" y="100px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/testsuite/cargo_information/verbose/stdout.term.svg
+++ b/tests/testsuite/cargo_information/verbose/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="254px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="326px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -43,7 +43,15 @@
 </tspan>
     <tspan x="10px" y="226px"><tspan>  feature2 = []</tspan>
 </tspan>
-    <tspan x="10px" y="244px">
+    <tspan x="10px" y="244px"><tspan class="fg-green bold">dependencies:</tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan>  bar@0.2.0</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan>  baz@0.3.0</tspan>
+</tspan>
+    <tspan x="10px" y="298px"><tspan>  foo@0.1.0</tspan>
+</tspan>
+    <tspan x="10px" y="316px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_information/within_ws_and_pick_ws_package/stdout.log
+++ b/tests/testsuite/cargo_information/within_ws_and_pick_ws_package/stdout.log
@@ -2,5 +2,3 @@ cargo-list-test-fixture
 version: 0.2.0 (from ./)
 license: unknown
 rust-version: unknown
-dependencies:
-  my-package@0.1


### PR DESCRIPTION
With public/private dependencies, we can at least show those.

Fixes #23