### PR TITLE
refactor: Prep for improving version selection from lockfile

### DIFF
--- a/src/ops/info.rs
+++ b/src/ops/info.rs
@@ -66,7 +66,10 @@ pub fn info(
     // Only suggest cargo tree command when the package is not a workspace member.
     // For workspace members, `cargo tree --package <SPEC> --invert` is useless. It only prints itself.
     let suggest_cargo_tree_command = package_id.is_some() && !is_member;
+    let summaries = query_summaries(spec, &mut registry, &source_ids)?;
+
     query_and_pretty_view(
+        &summaries,
         spec,
         package_id,
         config,
@@ -98,16 +101,15 @@ fn find_pkgid_in_ws(
 // Query the package registry and pretty print the result.
 // If package_id is None, find the latest version.
 fn query_and_pretty_view(
+    summaries: &[IndexSummary],
     spec: &PackageIdSpec,
     package_id: Option<PackageId>,
     config: &Config,
-    mut registry: PackageRegistry,
+    registry: PackageRegistry,
     source_ids: RegistrySourceIds,
     rustc_version: &semver::Version,
     suggest_cargo_tree_command: bool,
 ) -> CargoResult<()> {
-    let summaries = query_summaries(spec, &mut registry, &source_ids)?;
-
     let package_id = match package_id {
         Some(id) => id,
         None => {
@@ -154,7 +156,7 @@ fn query_and_pretty_view(
     let owners = try_list_owners(config, source_ids, package_id.name().as_str())?;
     pretty_view(
         package,
-        &summaries,
+        summaries,
         &owners,
         suggest_cargo_tree_command,
         config,

--- a/tests/testsuite/cargo_information/git_dependency/stderr.log
+++ b/tests/testsuite/cargo_information/git_dependency/stderr.log
@@ -1,1 +1,0 @@
-    Updating git repository `[ROOTURL]/baz`

--- a/tests/testsuite/cargo_information/within_ws_and_pick_ws_package/stderr.log
+++ b/tests/testsuite/cargo_information/within_ws_and_pick_ws_package/stderr.log
@@ -1,1 +1,0 @@
-    Updating `dummy-registry` index


### PR DESCRIPTION
This is prep for #29.  The main focus is on making it easier to make the package id lookups more complex by moving them out to functions.