### PR TITLE
test: Capture dimmed state in SVGs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",

--- a/tests/testsuite/cargo_information/verbose/stdout.term.svg
+++ b/tests/testsuite/cargo_information/verbose/stdout.term.svg
@@ -9,6 +9,7 @@
       line-height: 18px;
     }
     .bold { font-weight: bold; }
+    .dimmed { opacity: 0.7; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -47,7 +48,7 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>  bar@0.2.0</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  baz@0.3.0</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="dimmed">baz@0.3.0</tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan>  foo@0.1.0</tspan>
 </tspan>


### PR DESCRIPTION
anstyle-svg uses a parser from `anstream` to extract state.  A newer `anstream` is needed to correctly parse "dimmed" so it can be represented in snapshots.