### PR TITLE
chore: Upgrade snapbox to 0.5.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ dependencies = [
  "crates-io 0.40.0",
  "pathdiff",
  "semver",
- "snapbox 0.5.10",
+ "snapbox 0.5.14",
  "trycmd",
 ]
 
@@ -408,7 +408,7 @@ dependencies = [
  "pasetors",
  "serde",
  "serde_json",
- "snapbox 0.5.10",
+ "snapbox 0.5.14",
  "tar",
  "time",
  "toml",
@@ -2841,9 +2841,9 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "snapbox"
-version = "0.5.10"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f1918ec224cc1fd581ff833603f7d203b2cbe36f725e030255f1143a48ba5d"
+checksum = "f37d101fcafc8e73748fd8a1b7048f5979f93d372fd17027d7724c1643bc379b"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ semver = "1.0.22"
 [dev-dependencies]
 cargo-test-macro = { git = "https://github.com/rust-lang/cargo.git" }
 cargo-test-support = { git = "https://github.com/rust-lang/cargo.git" }
-snapbox = { version = "0.5.9", features = ["diff", "path", "term-svg"] }
+snapbox = { version = "0.5.14", features = ["diff", "path", "term-svg"] }
 trycmd = "0.15.1"
 
 [[bin]]

--- a/tests/testsuite/cargo_information/basic/mod.rs
+++ b/tests/testsuite/cargo_information/basic/mod.rs
@@ -46,6 +46,6 @@ fn case() {
         .arg("--registry=dummy-registry")
         .assert()
         .success()
-        .stdout_matches(file!["stdout.term.svg"])
-        .stderr_matches(file!["stderr.term.svg"]);
+        .stdout_eq_(file!["stdout.term.svg"])
+        .stderr_eq_(file!["stderr.term.svg"]);
 }

--- a/tests/testsuite/cargo_information/features/mod.rs
+++ b/tests/testsuite/cargo_information/features/mod.rs
@@ -17,6 +17,6 @@ fn case() {
         .arg("--registry=dummy-registry")
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 }

--- a/tests/testsuite/cargo_information/features_activated_over_limit/mod.rs
+++ b/tests/testsuite/cargo_information/features_activated_over_limit/mod.rs
@@ -30,6 +30,6 @@ fn case() {
         .arg("--registry=dummy-registry")
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 }

--- a/tests/testsuite/cargo_information/features_activated_over_limit_verbose/mod.rs
+++ b/tests/testsuite/cargo_information/features_activated_over_limit_verbose/mod.rs
@@ -31,6 +31,6 @@ fn case() {
         .arg("--registry=dummy-registry")
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 }

--- a/tests/testsuite/cargo_information/features_deactivated_over_limit/mod.rs
+++ b/tests/testsuite/cargo_information/features_deactivated_over_limit/mod.rs
@@ -30,6 +30,6 @@ fn case() {
         .arg("--registry=dummy-registry")
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 }

--- a/tests/testsuite/cargo_information/git_dependency/mod.rs
+++ b/tests/testsuite/cargo_information/git_dependency/mod.rs
@@ -38,6 +38,6 @@ fn case() {
         .current_dir(cwd)
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 }

--- a/tests/testsuite/cargo_information/help/mod.rs
+++ b/tests/testsuite/cargo_information/help/mod.rs
@@ -10,6 +10,6 @@ fn case() {
         .arg("--registry=dummy-registry")
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 }

--- a/tests/testsuite/cargo_information/not_found/mod.rs
+++ b/tests/testsuite/cargo_information/not_found/mod.rs
@@ -16,8 +16,8 @@ fn case() {
         .current_dir(cwd)
         .assert()
         .failure()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 
     assert_ui().subset_matches(current_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_information/path_dependency/mod.rs
+++ b/tests/testsuite/cargo_information/path_dependency/mod.rs
@@ -16,8 +16,8 @@ fn case() {
         .current_dir(cwd)
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 
     assert_ui().subset_matches(current_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_information/pick_msrv_compatible_package/mod.rs
+++ b/tests/testsuite/cargo_information/pick_msrv_compatible_package/mod.rs
@@ -18,6 +18,6 @@ fn case() {
         .arg("--registry=dummy-registry")
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 }

--- a/tests/testsuite/cargo_information/pick_msrv_compatible_package_within_ws/mod.rs
+++ b/tests/testsuite/cargo_information/pick_msrv_compatible_package_within_ws/mod.rs
@@ -24,8 +24,8 @@ fn case() {
         .current_dir(cwd)
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 
     assert_ui().subset_matches(current_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_information/pick_msrv_compatible_package_within_ws_and_use_msrv_from_ws/mod.rs
+++ b/tests/testsuite/cargo_information/pick_msrv_compatible_package_within_ws_and_use_msrv_from_ws/mod.rs
@@ -24,8 +24,8 @@ fn case() {
         .current_dir(cwd)
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 
     assert_ui().subset_matches(current_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_information/specify_empty_version_with_url/mod.rs
+++ b/tests/testsuite/cargo_information/specify_empty_version_with_url/mod.rs
@@ -18,6 +18,6 @@ fn case() {
         .arg("--registry=alternative")
         .assert()
         .failure()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 }

--- a/tests/testsuite/cargo_information/specify_version_outside_ws/mod.rs
+++ b/tests/testsuite/cargo_information/specify_version_outside_ws/mod.rs
@@ -14,6 +14,6 @@ fn case() {
         .arg("--registry=dummy-registry")
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 }

--- a/tests/testsuite/cargo_information/specify_version_with_url_but_registry_is_not_matched/mod.rs
+++ b/tests/testsuite/cargo_information/specify_version_with_url_but_registry_is_not_matched/mod.rs
@@ -18,6 +18,6 @@ fn case() {
         .arg("--registry=alternative")
         .assert()
         .failure()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 }

--- a/tests/testsuite/cargo_information/specify_version_within_ws_and_conflict_with_lockfile/mod.rs
+++ b/tests/testsuite/cargo_information/specify_version_within_ws_and_conflict_with_lockfile/mod.rs
@@ -28,8 +28,8 @@ fn case() {
         .current_dir(cwd)
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 
     assert_ui().subset_matches(current_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_information/specify_version_within_ws_and_match_with_lockfile/mod.rs
+++ b/tests/testsuite/cargo_information/specify_version_within_ws_and_match_with_lockfile/mod.rs
@@ -28,8 +28,8 @@ fn case() {
         .current_dir(cwd)
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 
     assert_ui().subset_matches(current_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_information/transitive_dependency_within_ws/mod.rs
+++ b/tests/testsuite/cargo_information/transitive_dependency_within_ws/mod.rs
@@ -38,36 +38,36 @@ fn case() {
         .arg("--registry=dummy-registry")
         .current_dir(ws_directory)
         .assert()
-        .stdout_matches(file!["ws.stdout.log"])
-        .stderr_matches(file!["ws.stderr.log"]);
+        .stdout_eq_(file!["ws.stdout.log"])
+        .stderr_eq_(file!["ws.stderr.log"]);
     cargo_info()
         .arg("my-package")
         .arg("--registry=dummy-registry")
         .current_dir(transitive1_directory)
         .assert()
-        .stdout_matches(file!["transitive1.stdout.log"])
-        .stderr_matches(file!["transitive1.stderr.log"]);
+        .stdout_eq_(file!["transitive1.stdout.log"])
+        .stderr_eq_(file!["transitive1.stderr.log"]);
     cargo_info()
         .arg("my-package")
         .arg("--registry=dummy-registry")
         .current_dir(transitive2_directory)
         .assert()
-        .stdout_matches(file!["transitive2.stdout.log"])
-        .stderr_matches(file!["transitive2.stderr.log"]);
+        .stdout_eq_(file!["transitive2.stdout.log"])
+        .stderr_eq_(file!["transitive2.stderr.log"]);
     cargo_info()
         .arg("my-package")
         .arg("--registry=dummy-registry")
         .current_dir(direct1_directory)
         .assert()
-        .stdout_matches(file!["direct1.stdout.log"])
-        .stderr_matches(file!["direct1.stderr.log"]);
+        .stdout_eq_(file!["direct1.stdout.log"])
+        .stderr_eq_(file!["direct1.stderr.log"]);
     cargo_info()
         .arg("my-package")
         .arg("--registry=dummy-registry")
         .current_dir(direct2_directory)
         .assert()
-        .stdout_matches(file!["direct2.stdout.log"])
-        .stderr_matches(file!["direct2.stderr.log"]);
+        .stdout_eq_(file!["direct2.stdout.log"])
+        .stderr_eq_(file!["direct2.stderr.log"]);
 
     assert_ui().subset_matches(current_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_information/verbose/mod.rs
+++ b/tests/testsuite/cargo_information/verbose/mod.rs
@@ -47,6 +47,6 @@ fn case() {
         .arg("--registry=dummy-registry")
         .assert()
         .success()
-        .stdout_matches(file!["stdout.term.svg"])
-        .stderr_matches(file!["stderr.term.svg"]);
+        .stdout_eq_(file!["stdout.term.svg"])
+        .stderr_eq_(file!["stderr.term.svg"]);
 }

--- a/tests/testsuite/cargo_information/with_frozen_outside_ws/mod.rs
+++ b/tests/testsuite/cargo_information/with_frozen_outside_ws/mod.rs
@@ -24,6 +24,6 @@ fn case() {
         .arg("--registry=dummy-registry")
         .assert()
         .failure()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 }

--- a/tests/testsuite/cargo_information/with_frozen_within_ws/mod.rs
+++ b/tests/testsuite/cargo_information/with_frozen_within_ws/mod.rs
@@ -29,8 +29,8 @@ fn case() {
         .current_dir(cwd)
         .assert()
         .failure()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 
     assert_ui().subset_matches(current_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_information/with_locked_outside_ws/mod.rs
+++ b/tests/testsuite/cargo_information/with_locked_outside_ws/mod.rs
@@ -24,6 +24,6 @@ fn case() {
         .arg("--registry=dummy-registry")
         .assert()
         .failure()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 }

--- a/tests/testsuite/cargo_information/with_locked_within_ws/mod.rs
+++ b/tests/testsuite/cargo_information/with_locked_within_ws/mod.rs
@@ -29,8 +29,8 @@ fn case() {
         .current_dir(cwd)
         .assert()
         .failure()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 
     assert_ui().subset_matches(current_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_information/with_offline/mod.rs
+++ b/tests/testsuite/cargo_information/with_offline/mod.rs
@@ -24,6 +24,6 @@ fn case() {
         .arg("--registry=dummy-registry")
         .assert()
         .failure()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 }

--- a/tests/testsuite/cargo_information/with_quiet/mod.rs
+++ b/tests/testsuite/cargo_information/with_quiet/mod.rs
@@ -24,6 +24,6 @@ fn case() {
         .arg("--registry=dummy-registry")
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 }

--- a/tests/testsuite/cargo_information/within_ws/mod.rs
+++ b/tests/testsuite/cargo_information/within_ws/mod.rs
@@ -28,8 +28,8 @@ fn case() {
         .current_dir(cwd)
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 
     assert_ui().subset_matches(current_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_information/within_ws_and_pick_ws_package/mod.rs
+++ b/tests/testsuite/cargo_information/within_ws_and_pick_ws_package/mod.rs
@@ -19,8 +19,8 @@ fn case() {
         .current_dir(cwd)
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 
     assert_ui().subset_matches(current_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_information/within_ws_with_alternative_registry/mod.rs
+++ b/tests/testsuite/cargo_information/within_ws_with_alternative_registry/mod.rs
@@ -24,8 +24,8 @@ fn case() {
         .current_dir(cwd)
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 
     assert_ui().subset_matches(current_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_information/within_ws_without_lockfile/mod.rs
+++ b/tests/testsuite/cargo_information/within_ws_without_lockfile/mod.rs
@@ -25,8 +25,8 @@ fn case() {
         .current_dir(cwd)
         .assert()
         .success()
-        .stdout_matches(file!["stdout.log"])
-        .stderr_matches(file!["stderr.log"]);
+        .stdout_eq_(file!["stdout.log"])
+        .stderr_eq_(file!["stderr.log"]);
 
     assert_ui().subset_matches(current_dir!().join("out"), &project_root);
 }


### PR DESCRIPTION
This makes the upgrade to 0.6 trivial once cargo-test-support upgrades